### PR TITLE
Create pacaudit-post.hook

### DIFF
--- a/pacaudit-post.hook
+++ b/pacaudit-post.hook
@@ -1,0 +1,12 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Type = Package
+Target = *
+
+[Action]
+Depends = coreutils
+Depends = go
+When = PostTransaction
+Exec = if [ "$(/usr/bin/pacaudit -n)" != "OK" ]; then /usr/bin/pacaudit -n && /usr/bin/pacaudit -v; fi


### PR DESCRIPTION
A `pacaudit` post-transaction hook to install as `/usr/share/libalpm/hooks/pacaudit-post.hook`.

@steffenfritz 
It would be nice if `pacaudit` was oh so slightly more informational when running `pacaudit -n`, like `CRITICAL 31 vulnerable package(s) found!` instead of just: `CRITICAL`. Or perhaps this was intentional, which is ok, but maybe another flag which produces verbose output or invoking it twice like `-nn`.

Also, allow the flags to be used together, like `-vn` instead of `-v -n`. Currently their outputs are buggy forcing me to invoke `pacaudit` twice in my PR. See:
```
$ pacaudit -v -n
php-7.3.11-1                     |Critical |CVE-2019-11043
Critical
$
```
As opposed to the more readable:
```
$ pacaudit -n && pacaudit -v
Critical
php-7.3.11-1                     |Critical |CVE-2019-11043
1 vulnerable package(s) installed.
$
```
TODO: A nice next step would be to add a `pacaudit` _pre-transaction hook_ that checks if vulnerable packages have been chosen for install.